### PR TITLE
Fix bug where status of task is not updated after done

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DoneTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DoneTaskCommand.java
@@ -1,19 +1,26 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_TASKS;
 
 import java.util.List;
+import java.util.Set;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.common.Category;
+import seedu.address.model.common.Date;
+import seedu.address.model.common.Name;
+import seedu.address.model.common.Tag;
+import seedu.address.model.task.Priority;
 import seedu.address.model.task.Task;
 
 
-
-
-
+/**
+ * Marks the status of an incomplete task as complete.
+ */
 public class DoneTaskCommand extends Command {
     public static final String COMMAND_WORD = "done_task";
 
@@ -23,6 +30,7 @@ public class DoneTaskCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_DONE_TASK_SUCCESS = "Completed Task: %1$s";
+    public static final String MESSAGE_TASK_ALREADY_COMPLETE = "This task has already been marked as complete.";
 
     private final Index targetIndex;
 
@@ -41,14 +49,55 @@ public class DoneTaskCommand extends Command {
         requireNonNull(model);
         List<Task> lastShownList = model.getFilteredTaskList();
 
+        // verify if index is valid
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
         }
 
         Task taskToComplete = lastShownList.get(targetIndex.getZeroBased());
+        // verify if task is already completed
+        if (taskToComplete.isComplete()) {
+            throw new CommandException(MESSAGE_TASK_ALREADY_COMPLETE);
+        }
 
-        model.doneTask(taskToComplete);
+        Task completedTask = createCompletedTask(taskToComplete);
+
+        // replace the old task with the new and completed task and update
+        model.setTask(taskToComplete, completedTask);
+        model.updateFilteredTaskList(PREDICATE_SHOW_ALL_TASKS);
         return new CommandResult(String.format(MESSAGE_DONE_TASK_SUCCESS, taskToComplete));
+    }
+
+    /**
+     * Creates and returns a {@code Task} with the same details of {@code taskToComplete},
+     * but completionStatus as complete.
+     *
+     * @param taskToComplete task to be marked as complete.
+     * @return a completed task.
+     */
+    private static Task createCompletedTask(Task taskToComplete) {
+        assert taskToComplete != null;
+
+        Task completedTask = copyTask(taskToComplete);
+        completedTask.markTaskAsDone();
+        return completedTask;
+    }
+
+    /**
+     * Copies the task given and returns a new task with the same details as the given task.
+     *
+     * @param taskToCopy task to be copied, here is the task to be completed.
+     * @return a copied task.
+     */
+    private static Task copyTask(Task taskToCopy) {
+        Name taskName = taskToCopy.getName();
+        Date deadline = taskToCopy.getDeadline();
+        Priority priority = taskToCopy.getPriority();
+        Set<Category> categories = taskToCopy.getCategories();
+        Set<Tag> tags = taskToCopy.getTags();
+
+        Task completedTask = new Task(taskName, deadline, priority, categories, tags);
+        return completedTask;
     }
 
     @Override
@@ -57,4 +106,5 @@ public class DoneTaskCommand extends Command {
                 || (other instanceof DoneTaskCommand // instanceof handles nulls
                 && targetIndex.equals(((DoneTaskCommand) other).targetIndex)); // state check
     }
+
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -238,8 +238,9 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void doneTask(Task target) {
-        target.markTaskAsDone();
+    public void doneTask(Task task) {
+        requireAllNonNull(task);
+        sochedule.doneTask(task);
     }
 
     /**

--- a/src/main/java/seedu/address/model/task/CompletionStatus.java
+++ b/src/main/java/seedu/address/model/task/CompletionStatus.java
@@ -56,6 +56,14 @@ public class CompletionStatus {
     }
 
     /**
+     * Updates the completion status of the task to COMPLETE;
+     * Guarantees: task is currently incomplete.
+     */
+    public void markAsDone() {
+        completionStatus = Status.COMPLETE;
+    }
+
+    /**
      * Returns true if a given string is a valid completion status.
      */
     public static boolean isValidStatus(String test) {

--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -64,7 +64,7 @@ public class Task {
     }
 
     public void markTaskAsDone() {
-        completionStatus.flipCompletionStatus();
+        completionStatus.markAsDone();
     }
 
     /**


### PR DESCRIPTION
Currently, a task is directly assessed and getting its status updated as complete.
However, since this does not update the observable task list and filtered task list,
this changes are not reflected unless the app restarts.

We can create a new task with the status marked as complete and replace the old task
with the new task. This is essentially a simplified edit task command. It is easy to be adapted
and can be helpful for building edit command in the next iteration.

Let's do the changes!

Closes #122 