### PR TITLE
[Model] update isSame method for Task and Event

### DIFF
--- a/src/main/java/seedu/address/model/event/Event.java
+++ b/src/main/java/seedu/address/model/event/Event.java
@@ -78,7 +78,13 @@ public class Event {
         }
 
         return otherEvent != null
-                && otherEvent.getName().equals(getName());
+                && otherEvent.getName().equals(getName())
+                && otherEvent.getStartDate().equals(getStartDate())
+                && otherEvent.getStartTime().equals(getStartTime())
+                && otherEvent.getEndDate().equals(getEndDate())
+                && otherEvent.getEndTime().equals(getEndTime())
+                && otherEvent.getCategories().equals(getCategories())
+                && otherEvent.getTags().equals(getTags());
     }
 
     /**

--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -69,7 +69,7 @@ public class Task {
     }
 
     /**
-     * Returns true if both tasks have the same name, deadline, priority, categories and tags.
+     * Returns true if both tasks have the same name, deadline, priority, tags and categories.
      * This defines a weaker notion of equality between two tasks.
      */
     public boolean isSameTask(Task otherTask) {

--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -69,7 +69,7 @@ public class Task {
     }
 
     /**
-     * Returns true if both tasks have the same name.
+     * Returns true if both tasks have the same name, deadline, priority, categories and tags.
      * This defines a weaker notion of equality between two tasks.
      */
     public boolean isSameTask(Task otherTask) {
@@ -78,7 +78,11 @@ public class Task {
         }
 
         return otherTask != null
-                && otherTask.getName().equals(getName());
+                && otherTask.getName().equals(getName())
+                && otherTask.getDeadline().equals(getDeadline())
+                && otherTask.getPriority().equals(getPriority())
+                && otherTask.getCategories().equals(getCategories())
+                && otherTask.getTags().equals(getTags());
     }
 
     /**

--- a/src/test/java/seedu/address/model/SocheduleTest.java
+++ b/src/test/java/seedu/address/model/SocheduleTest.java
@@ -5,12 +5,18 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_CATEGORY_HOMEWORK;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DEADLINE_TASKONE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EVENT_CATEGORY_INTERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EVENT_ENDDATE_INTERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EVENT_ENDTIME_INTERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EVENT_NAME_INTERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EVENT_STARTDATE_INTERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EVENT_STARTTIME_INTERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EVENT_TAG_INTERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PRIORITY_TASKONE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_IMPORTANT;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalEvents.DATE;
+import static seedu.address.testutil.TypicalEvents.INTERVIEW;
 import static seedu.address.testutil.TypicalEvents.MEETING;
 import static seedu.address.testutil.TypicalTasks.ASSIGNMENT;
 import static seedu.address.testutil.TypicalTasks.LAB;
@@ -78,10 +84,12 @@ public class SocheduleTest {
         List<Task> newTasks = Arrays.asList(ASSIGNMENT, LAB);
 
         // Two events with the same identity fields
-        Event editedMeeting = new EventBuilder(MEETING).withStartDate(VALID_EVENT_STARTDATE_INTERVIEW)
-                .withTags(VALID_EVENT_TAG_INTERVIEW)
+        Event eventWithSameIdentity = new EventBuilder().withName(VALID_EVENT_NAME_INTERVIEW)
+                .withStartDate(VALID_EVENT_STARTDATE_INTERVIEW).withStartTime(VALID_EVENT_STARTTIME_INTERVIEW)
+                .withEndDate(VALID_EVENT_ENDDATE_INTERVIEW).withEndTime(VALID_EVENT_ENDTIME_INTERVIEW)
+                .withTags(VALID_EVENT_TAG_INTERVIEW).withCategories(VALID_EVENT_CATEGORY_INTERVIEW)
                 .build();
-        List<Event> newEvents = Arrays.asList(MEETING, editedMeeting);
+        List<Event> newEvents = Arrays.asList(INTERVIEW, eventWithSameIdentity);
         SocheduleStub newData = new SocheduleStub(newTasks, newEvents);
 
         assertThrows(DuplicateEventException.class, () -> sochedule.resetData(newData));
@@ -131,12 +139,13 @@ public class SocheduleTest {
 
     @Test
     public void hasEvent_eventWithSameIdentityFieldsInSochedule_returnsTrue() {
-        sochedule.addEvent(MEETING);
-        Event editedMeeting = new EventBuilder(MEETING)
-                .withStartDate(VALID_EVENT_STARTDATE_INTERVIEW)
-                .withTags(VALID_EVENT_TAG_INTERVIEW)
+        sochedule.addEvent(INTERVIEW);
+        Event eventWithSameIdentity = new EventBuilder().withName(VALID_EVENT_NAME_INTERVIEW)
+                .withStartDate(VALID_EVENT_STARTDATE_INTERVIEW).withStartTime(VALID_EVENT_STARTTIME_INTERVIEW)
+                .withEndDate(VALID_EVENT_ENDDATE_INTERVIEW).withEndTime(VALID_EVENT_ENDTIME_INTERVIEW)
+                .withTags(VALID_EVENT_TAG_INTERVIEW).withCategories(VALID_EVENT_CATEGORY_INTERVIEW)
                 .build();
-        assertTrue(sochedule.hasEvent(editedMeeting));
+        assertTrue(sochedule.hasEvent(eventWithSameIdentity));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/SocheduleTest.java
+++ b/src/test/java/seedu/address/model/SocheduleTest.java
@@ -3,15 +3,18 @@ package seedu.address.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_CATEGORY_HOMEWORK;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DEADLINE_TASKONE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EVENT_STARTDATE_INTERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EVENT_TAG_INTERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PRIORITY_TASKONE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_IMPORTANT;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalEvents.DATE;
 import static seedu.address.testutil.TypicalEvents.MEETING;
 import static seedu.address.testutil.TypicalTasks.ASSIGNMENT;
 import static seedu.address.testutil.TypicalTasks.LAB;
+import static seedu.address.testutil.TypicalTasks.TASKONE;
 import static seedu.address.testutil.TypicalTasks.getTypicalSochedule;
 
 import java.util.Arrays;
@@ -56,10 +59,11 @@ public class SocheduleTest {
     @Test
     public void resetData_withDuplicateTasks_throwsDuplicateTaskException() {
         // Two tasks with the same identity fields
-        Task editedAssignment = new TaskBuilder(ASSIGNMENT).withDeadline(VALID_DEADLINE_TASKONE)
-                .withTags(VALID_TAG_IMPORTANT)
+        Task taskWithSameIdentity = new TaskBuilder(TASKONE)
+                .withDeadline(VALID_DEADLINE_TASKONE).withPriority(VALID_PRIORITY_TASKONE)
+                .withCategories(VALID_CATEGORY_HOMEWORK).withTags(VALID_TAG_IMPORTANT)
                 .build();
-        List<Task> newTasks = Arrays.asList(ASSIGNMENT, editedAssignment);
+        List<Task> newTasks = Arrays.asList(TASKONE, taskWithSameIdentity);
 
         // Two different events
         List<Event> newEvents = Arrays.asList(MEETING, DATE);
@@ -117,11 +121,12 @@ public class SocheduleTest {
 
     @Test
     public void hasTask_taskWithSameIdentityFieldsInSochedule_returnsTrue() {
-        sochedule.addTask(ASSIGNMENT);
-        Task editedAssignment = new TaskBuilder(ASSIGNMENT)
-                .withDeadline(VALID_DEADLINE_TASKONE).withTags(VALID_TAG_IMPORTANT)
+        sochedule.addTask(TASKONE);
+        Task taskWithSameIdentity = new TaskBuilder(TASKONE)
+                .withDeadline(VALID_DEADLINE_TASKONE).withPriority(VALID_PRIORITY_TASKONE)
+                .withCategories(VALID_CATEGORY_HOMEWORK).withTags(VALID_TAG_IMPORTANT)
                 .build();
-        assertTrue(sochedule.hasTask(editedAssignment));
+        assertTrue(sochedule.hasTask(taskWithSameIdentity));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/event/UniqueEventListTest.java
+++ b/src/test/java/seedu/address/model/event/UniqueEventListTest.java
@@ -3,7 +3,14 @@ package seedu.address.model.event;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EVENT_CATEGORY_INTERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EVENT_ENDDATE_INTERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EVENT_ENDTIME_INTERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EVENT_ENDTIME_ORIENTATION;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EVENT_NAME_INTERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EVENT_STARTDATE_INTERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EVENT_STARTTIME_INTERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EVENT_TAG_INTERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EVENT_TAG_ORIENTATION;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalEvents.INTERVIEW;
@@ -42,8 +49,11 @@ public class UniqueEventListTest {
     @Test
     public void contains_eventWithSameIdentityFieldsInList_returnsTrue() {
         uniqueEventList.add(INTERVIEW);
-        Event editedInterview = new EventBuilder(INTERVIEW).withEndTime(VALID_EVENT_ENDTIME_ORIENTATION)
-                .withTags(VALID_EVENT_TAG_ORIENTATION).build();
+        Event editedInterview = new EventBuilder().withName(VALID_EVENT_NAME_INTERVIEW)
+                .withStartDate(VALID_EVENT_STARTDATE_INTERVIEW).withStartTime(VALID_EVENT_STARTTIME_INTERVIEW)
+                .withEndDate(VALID_EVENT_ENDDATE_INTERVIEW).withEndTime(VALID_EVENT_ENDTIME_INTERVIEW)
+                .withTags(VALID_EVENT_TAG_INTERVIEW).withCategories(VALID_EVENT_CATEGORY_INTERVIEW)
+                .build();
         assertTrue(uniqueEventList.contains(editedInterview));
     }
 

--- a/src/test/java/seedu/address/model/task/TaskTest.java
+++ b/src/test/java/seedu/address/model/task/TaskTest.java
@@ -31,12 +31,12 @@ public class TaskTest {
         // null -> returns false
         assertFalse(ASSIGNMENT.isSameTask(null));
 
-        // same name, all other attributes different -> returns true
+        // same name, all other attributes different -> returns false
         Task editedAssignment = new TaskBuilder(ASSIGNMENT).withDeadline(VALID_DEADLINE_TASKONE)
                 .withPriority(VALID_PRIORITY_TASKONE)
                 .withCategories(VALID_CATEGORY_HOMEWORK)
                 .withTags(VALID_TAG_IMPORTANT).build();
-        assertTrue(ASSIGNMENT.isSameTask(editedAssignment));
+        assertFalse(ASSIGNMENT.isSameTask(editedAssignment));
 
         // different name, all other attributes same -> returns false
         editedAssignment = new TaskBuilder(ASSIGNMENT).withName(VALID_NAME_TASKONE).build();

--- a/src/test/java/seedu/address/model/task/UniqueTaskListTest.java
+++ b/src/test/java/seedu/address/model/task/UniqueTaskListTest.java
@@ -3,11 +3,15 @@ package seedu.address.model.task;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_CATEGORY_HOMEWORK;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_CATEGORY_PROJECT;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DEADLINE_TASKONE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PRIORITY_TASKONE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_IMPORTANT;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalTasks.ASSIGNMENT;
 import static seedu.address.testutil.TypicalTasks.LAB;
+import static seedu.address.testutil.TypicalTasks.TASKONE;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -41,10 +45,12 @@ public class UniqueTaskListTest {
 
     @Test
     public void contains_taskWithSameIdentityFieldsInList_returnsTrue() {
-        uniqueTaskList.add(ASSIGNMENT);
-        Task editedAssignment = new TaskBuilder(ASSIGNMENT).withDeadline(VALID_DEADLINE_TASKONE)
-                .withCategories(VALID_CATEGORY_PROJECT).build();
-        assertTrue(uniqueTaskList.contains(editedAssignment));
+        uniqueTaskList.add(TASKONE);
+        Task taskWithSameIdentity = new TaskBuilder(TASKONE)
+                .withDeadline(VALID_DEADLINE_TASKONE).withPriority(VALID_PRIORITY_TASKONE)
+                .withCategories(VALID_CATEGORY_HOMEWORK).withTags(VALID_TAG_IMPORTANT)
+                .build();
+        assertTrue(uniqueTaskList.contains(taskWithSameIdentity));
     }
 
 


### PR DESCRIPTION
For task and events, currently isSame method only checks if the name is the same.

Let's add the checks for task to include checking for name, deadline, priority, categories and tags.
Let's add the checks for event to include checking for name, startdate, starttime, enddate, endtime, categories and tags.

This is because tasks and events can have same name but occur at different dates or with different categories/tags etc. For example, I can have a test on monday and a test on sunday, this should be allowed. Completion status is not checked for task.

Closes #130