### PR TITLE
Add pin_task and unpin_task command support

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -255,6 +255,30 @@ The sequence diagram for `sortTaskCommand` can be found below.
 
 ![Sequence Diagram of SortTask Command](images/SortTaskSequenceDiagram.png)
 
+**Implementation of PinTaskCommand/UnpinTaskCommand**
+The following is a detailed explanation on how PinTaskCommand is implemented.
+UnpinTaskCommand is largely similar in implementation to PinTaskCommand and will be omitted for brevity.
+
+**Step 1**: User executes `pin_task INDEX` command to delete the task at the given index.
+An `PinTaskParser` object is created, and the `PinTaskParser#parse(String args)` method is called.
+The method conducts parses the `args` and conducts validation checks to ensure that it complies with the specification.
+A `PinTaskCommand` object is returned.
+
+**Step 2**: On `PinTaskCommand#execute()`, `Model#pinTask(Task task)` is called.
+This will pin the task at the specified index.
+Subsequently, the underlying task list will be sorted by calling `Model#sortTasksDefault()`, with pinned tasks being first in priority, followed by the last sorted variable 
+(if `sort_task` was not called before, task list will be sorted by name).
+For brevity, lower level implementation of `Model#pinTask(Task task)` is omitted.
+
+**Step 3**: On execution completion a `CommandResult` is created.
+A success message will be appended with `CommandResult#MESSAGE_PIN_TASK_SUCCESS`.
+The UI will also update as the underlying task list has been modified.
+
+Since the sequence diagram for `PinTaskCommand` is similar to `SortTaskCommand`, it is omitted for brevity.
+
+Key differences as follows:
+* Instead of `SortTask`-related parsers and commands, `PinTask`-related parsers and commands are created and activated.
+
 ### 4.3 Event
 
 #### 4.3.1 Overview

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -205,6 +205,8 @@ Action | Format, Examples
 **Done** | `done_task INDEX`<br>e.g., `done_task 1`
 **List** | `list_task`
 **Sort** | `sort_task ARGUMENT`<br>e.g., `sort_task name`
+**Pin** | `pin_task INDEX`<br>e.g., `pin_task 1`
+**Unpin** | `unpin_task INDEX`<br>e.g., `unpin_task 1`
 **Clear completed** | `clear_completed_task`
 **Clear expired** | `clear_expired_task`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -12,6 +12,8 @@ SOChedule is a one-stop solution for managing tasks and events, optimized for us
 * Listing all tasks: `list_task`
 * Marking a task as done : `done_task`
 * Sorting all tasks: `sort_task`
+* Pinning a task: `pin_task`
+* Unpinning a task: `unpin_task`
 * Clearing completed tasks: `clear_completed_task`
 * Clearing expired tasks: `clear_expired_task`
 * Adding an event: `add_event`
@@ -105,6 +107,30 @@ Format: `sort_task ARGUMENT`
 Examples:
 * `sort_task completion` sorts the task list by completion status.
 * `sort_task name` sorts the task list by name.
+
+### Pinning a task: `pin_task`
+Pins a task from SOChedule Task List.
+
+Format: `pin_task INDEX`
+* Pins the task at the specified INDEX.
+* Already pinned tasks will be unable to be pinned a second time.
+* The index refers to the index number shown in the displayed task list.
+* The index must be a positive and valid integer 1, 2, 3, ...
+* After pinning, the Task List will be sorted either according to previously entered `sort_task` command, or name (by default).
+* Pinned tasks are persistent over instances of SOChedule.
+
+Examples:
+* `pin_task 1` pins the first task in Task List
+
+### Unpinning a task: `unpin_task`
+Unpins a task from SOChedule Task List.
+
+Format: `unpin_task INDEX`
+* Unpins the task at the specified INDEX.
+* Follows similar restrictions to `pin_task`
+
+Examples:
+* `unpin_task 1` unpins the first task in Task List
 
 ### Clearing completed tasks: `clear_completed_task`
 Clear tasks marked as completed.

--- a/src/main/java/seedu/address/logic/commands/DoneTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DoneTaskCommand.java
@@ -97,6 +97,9 @@ public class DoneTaskCommand extends Command {
         Set<Tag> tags = taskToCopy.getTags();
 
         Task completedTask = new Task(taskName, deadline, priority, categories, tags);
+        if (taskToCopy.isPinned()) {
+            completedTask.pin();
+        }
         return completedTask;
     }
 

--- a/src/main/java/seedu/address/logic/commands/EditTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditTaskCommand.java
@@ -107,7 +107,11 @@ public class EditTaskCommand extends Command {
         Set<Category> updatedCategories = editTaskDescriptor.getCategories().orElse(taskToEdit.getCategories());
         Set<Tag> updatedTags = editTaskDescriptor.getTags().orElse(taskToEdit.getTags());
 
-        return new Task(updatedName, updatedDeadline, updatedPriority, updatedCategories, updatedTags);
+        Task editedTask = new Task(updatedName, updatedDeadline, updatedPriority, updatedCategories, updatedTags);
+        if (taskToEdit.isPinned()) {
+            editedTask.pin();
+        }
+        return editedTask;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/PinTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/PinTaskCommand.java
@@ -1,0 +1,113 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+import java.util.Set;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.common.Category;
+import seedu.address.model.common.Date;
+import seedu.address.model.common.Name;
+import seedu.address.model.common.Tag;
+import seedu.address.model.task.Priority;
+import seedu.address.model.task.Task;
+
+/**
+ * Pins a task.
+ */
+
+public class PinTaskCommand extends Command {
+    public static final String COMMAND_WORD = "pin_task";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Pins the task identified by the index number used in the displayed task list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_PIN_TASK_SUCCESS = "Pinned Task";
+    public static final String MESSAGE_TASK_ALREADY_PINNED = "This task is already pinned.";
+
+    private final Index targetIndex;
+
+    public PinTaskCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    /**
+     * Creates and returns a {@code Task} with the same details of {@code taskToPin},
+     * but pinnedStatus as pinned.
+     *
+     * @param taskToPin task to pin.
+     * @return a pinned task.
+     */
+    private static Task createPinnedTask(Task taskToPin) {
+        assert taskToPin != null;
+
+        Task pinnedTask = copyTask(taskToPin);
+        pinnedTask.pin();
+        return pinnedTask;
+    }
+
+    /**
+     * Copies the task given and returns a new task with the same details as the given task.
+     *
+     * @param taskToCopy task to be copied, here is the task to pin.
+     * @return a copied task.
+     */
+    private static Task copyTask(Task taskToCopy) {
+        Name taskName = taskToCopy.getName();
+        Date deadline = taskToCopy.getDeadline();
+        Priority priority = taskToCopy.getPriority();
+        Set<Category> categories = taskToCopy.getCategories();
+        Set<Tag> tags = taskToCopy.getTags();
+
+        Task copiedTask = new Task(taskName, deadline, priority, categories, tags);
+        if (taskToCopy.isComplete()) {
+            copiedTask.markTaskAsDone();
+        }
+        return copiedTask;
+    }
+
+    /**
+     * Executes the command and returns the result message.
+     * @param model {@code Model} which the command should operate on.
+     * @return feedback message of the operation result for display.
+     * @throws CommandException If an error occurs during command execution.
+     */
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Task> lastShownList = model.getFilteredTaskList();
+
+        // verify if index is valid
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
+        }
+
+        Task taskToPin = lastShownList.get(targetIndex.getZeroBased());
+        // verify is task is already pinned
+        if (taskToPin.isPinned()) {
+            throw new CommandException(MESSAGE_TASK_ALREADY_PINNED);
+        }
+
+        Task pinnedTask = createPinnedTask(taskToPin);
+
+        //replace the old task with the new and pinned task, update
+        model.setTask(taskToPin, pinnedTask);
+        model.sortTasksDefault();
+        model.updateFilteredTaskList(Model.PREDICATE_SHOW_ALL_TASKS);
+
+        return new CommandResult(MESSAGE_PIN_TASK_SUCCESS);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof PinTaskCommand // instanceof handles nulls
+                && targetIndex.equals(((PinTaskCommand) other).targetIndex)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/UnpinTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnpinTaskCommand.java
@@ -1,0 +1,99 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+import java.util.Set;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.common.Category;
+import seedu.address.model.common.Date;
+import seedu.address.model.common.Name;
+import seedu.address.model.common.Tag;
+import seedu.address.model.task.Priority;
+import seedu.address.model.task.Task;
+
+/**
+ * Pins a task.
+ */
+
+public class UnpinTaskCommand extends Command {
+    public static final String COMMAND_WORD = "unpin_task";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Unpins the task identified by the index number used in the displayed task list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_PIN_TASK_SUCCESS = "Unpinned Task";
+    public static final String MESSAGE_TASK_ALREADY_UNPINNED = "This task is not pinned to begin with.";
+
+    private final Index targetIndex;
+
+    public UnpinTaskCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    /**
+     * Copies the task given and returns a new task with the same details as the given task, without pinned attribute.
+     *
+     * @param taskToCopy task to be copied, here is the task to pin.
+     * @return a copied task.
+     */
+    private static Task copyAndUnpinTask(Task taskToCopy) {
+        Name taskName = taskToCopy.getName();
+        Date deadline = taskToCopy.getDeadline();
+        Priority priority = taskToCopy.getPriority();
+        Set<Category> categories = taskToCopy.getCategories();
+        Set<Tag> tags = taskToCopy.getTags();
+
+        //Just do not copy over the pinned attribute since it defaults to unpinned
+        Task copiedTask = new Task(taskName, deadline, priority, categories, tags);
+        if (taskToCopy.isComplete()) {
+            copiedTask.markTaskAsDone();
+        }
+        return copiedTask;
+    }
+
+    /**
+     * Executes the command and returns the result message.
+     * @param model {@code Model} which the command should operate on.
+     * @return feedback message of the operation result for display.
+     * @throws CommandException If an error occurs during command execution.
+     */
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Task> lastShownList = model.getFilteredTaskList();
+
+        // verify if index is valid
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
+        }
+
+        Task taskToUnpin = lastShownList.get(targetIndex.getZeroBased());
+        // verify is task is not pinned to begin with
+        if (!taskToUnpin.isPinned()) {
+            throw new CommandException(MESSAGE_TASK_ALREADY_UNPINNED);
+        }
+
+        Task unpinnedTask = copyAndUnpinTask(taskToUnpin);
+
+        //replace the old task with the new and pinned task, update
+        model.setTask(taskToUnpin, unpinnedTask);
+        model.sortTasksDefault();
+        model.updateFilteredTaskList(Model.PREDICATE_SHOW_ALL_TASKS);
+
+        return new CommandResult(MESSAGE_PIN_TASK_SUCCESS);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof UnpinTaskCommand // instanceof handles nulls
+                && targetIndex.equals(((UnpinTaskCommand) other).targetIndex)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/UnpinTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnpinTaskCommand.java
@@ -28,7 +28,7 @@ public class UnpinTaskCommand extends Command {
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_PIN_TASK_SUCCESS = "Unpinned Task";
+    public static final String MESSAGE_UNPIN_TASK_SUCCESS = "Unpinned Task";
     public static final String MESSAGE_TASK_ALREADY_UNPINNED = "This task is not pinned to begin with.";
 
     private final Index targetIndex;
@@ -87,7 +87,7 @@ public class UnpinTaskCommand extends Command {
         model.sortTasksDefault();
         model.updateFilteredTaskList(Model.PREDICATE_SHOW_ALL_TASKS);
 
-        return new CommandResult(MESSAGE_PIN_TASK_SUCCESS);
+        return new CommandResult(MESSAGE_UNPIN_TASK_SUCCESS);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/PinTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/PinTaskCommandParser.java
@@ -1,0 +1,24 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.PinTaskCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class PinTaskCommandParser implements Parser<PinTaskCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the PinTaskCommand
+     * and returns a PinTaskCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public PinTaskCommand parse(String args) throws ParseException {
+        try {
+            Index index = SocheduleParserUtil.parseIndex(args);
+            return new PinTaskCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, PinTaskCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/SocheduleParser.java
+++ b/src/main/java/seedu/address/logic/parser/SocheduleParser.java
@@ -21,9 +21,11 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListEventCommand;
 import seedu.address.logic.commands.ListTaskCommand;
+import seedu.address.logic.commands.PinTaskCommand;
 import seedu.address.logic.commands.SortEventCommand;
 import seedu.address.logic.commands.SortTaskCommand;
 import seedu.address.logic.commands.SummaryCommand;
+import seedu.address.logic.commands.UnpinTaskCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -74,6 +76,12 @@ public class SocheduleParser {
 
         case SortTaskCommand.COMMAND_WORD:
             return new SortTaskCommandParser().parse(arguments);
+
+        case PinTaskCommand.COMMAND_WORD:
+            return new PinTaskCommandParser().parse(arguments);
+
+        case UnpinTaskCommand.COMMAND_WORD:
+            return new UnpinTaskCommandParser().parse(arguments);
 
         case SortEventCommand.COMMAND_WORD:
             return new SortEventCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/UnpinTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnpinTaskCommandParser.java
@@ -1,0 +1,24 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.UnpinTaskCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class UnpinTaskCommandParser implements Parser<UnpinTaskCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the UnpinTaskCommand
+     * and returns a UnpinTaskCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public UnpinTaskCommand parse(String args) throws ParseException {
+        try {
+            Index index = SocheduleParserUtil.parseIndex(args);
+            return new UnpinTaskCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnpinTaskCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -114,6 +114,11 @@ public interface Model {
     void sortTasks(String comparingVar);
 
     /**
+     * Sorts the contents of this list using current {@code comparingVar}.
+     */
+    void sortTasksDefault();
+
+    /**
      * Returns the number of completed tasks.
      */
     int getNumCompletedTask();

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -87,6 +87,18 @@ public interface Model {
     void doneTask(Task task);
 
     /**
+     * Pins the given task.
+     * {@code task} must not already exist in the Sochedule.
+     */
+    void pinTask(Task task);
+
+    /**
+     * Unpins the given task.
+     * {@code task} must not already exist in the Sochedule.
+     */
+    void unpinTask(Task task);
+
+    /**
      * Replaces the given task {@code target} with {@code editedTask}.
      * {@code target} must exist in the Sochedule.
      * The task identity of {@code editedTask} must not be the same as another existing task in the Sochedule.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -144,6 +144,18 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void pinTask(Task task) {
+        requireAllNonNull(task);
+        sochedule.pinTask(task);
+    }
+
+    @Override
+    public void unpinTask(Task task) {
+        requireAllNonNull(task);
+        sochedule.unpinTask(task);
+    }
+
+    @Override
     public void sortTasks(String comparingVar) {
         requireNonNull(comparingVar);
         sochedule.sortTasks(comparingVar);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -162,6 +162,11 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void sortTasksDefault() {
+        sochedule.sortTasksDefault();
+    }
+
+    @Override
     public void clearExpiredTasks() {
         sochedule.clearExpiredTasks();
     }

--- a/src/main/java/seedu/address/model/Sochedule.java
+++ b/src/main/java/seedu/address/model/Sochedule.java
@@ -126,6 +126,22 @@ public class Sochedule implements ReadOnlySochedule {
     }
 
     /**
+     * Pins {@code key} from {@code Sochedule}.
+     * {@code task} must exist in Sochedule.
+     */
+    public void pinTask(Task task) {
+        task.pin();
+    }
+
+    /**
+     * Unpins {@code key} from {@code Sochedule}.
+     * {@code task} must exist in Sochedule.
+     */
+    public void unpinTask(Task task) {
+        task.unpin();
+    }
+
+    /**
      * Sorts the contents of this list given {@code comparingVar}.
      * {@code comparingVar} must be a valid parameter.
      *

--- a/src/main/java/seedu/address/model/Sochedule.java
+++ b/src/main/java/seedu/address/model/Sochedule.java
@@ -153,6 +153,13 @@ public class Sochedule implements ReadOnlySochedule {
     }
 
     /**
+     * Sorts the contents of this list using current {@code comparingVar}.
+     */
+    public void sortTasksDefault() {
+        tasks.sortDefault();
+    }
+
+    /**
      * Returns the number of completed tasks.
      */
     public int getNumCompletedTask() {

--- a/src/main/java/seedu/address/model/task/CompletionStatus.java
+++ b/src/main/java/seedu/address/model/task/CompletionStatus.java
@@ -91,9 +91,9 @@ public class CompletionStatus implements Comparable<CompletionStatus> {
      */
     public String toString() {
         if (completionStatus == Status.COMPLETE) {
-            return "Complete";
+            return "COMPLETE";
         } else {
-            return "Incomplete";
+            return "INCOMPLETE";
         }
     }
 

--- a/src/main/java/seedu/address/model/task/PinnedStatus.java
+++ b/src/main/java/seedu/address/model/task/PinnedStatus.java
@@ -7,7 +7,7 @@ package seedu.address.model.task;
 public class PinnedStatus implements Comparable<PinnedStatus> {
     public static final String VALIDATION_REGEX = "PINNED|UNPINNED";
     public static final String MESSAGE_CONSTRAINTS =
-            "Completion Statuses should only either by \"PINNED\" or \"UNPINNED\"";
+            "Pinned Statuses should only either by \"PINNED\" or \"UNPINNED\"";
 
     private Status pinnedStatus;
 
@@ -57,6 +57,13 @@ public class PinnedStatus implements Comparable<PinnedStatus> {
         } else {
             pinnedStatus = Status.PINNED;
         }
+    }
+
+    /**
+     * Returns true if a given string is a valid pinned status.
+     */
+    public static boolean isValidStatus(String test) {
+        return test.matches(VALIDATION_REGEX);
     }
 
     /**

--- a/src/main/java/seedu/address/model/task/PinnedStatus.java
+++ b/src/main/java/seedu/address/model/task/PinnedStatus.java
@@ -99,9 +99,9 @@ public class PinnedStatus implements Comparable<PinnedStatus> {
      */
     public String toString() {
         if (pinnedStatus == Status.PINNED) {
-            return "Pinned";
+            return "PINNED";
         } else {
-            return "Unpinned";
+            return "UNPINNED";
         }
     }
 

--- a/src/main/java/seedu/address/model/task/PinnedStatus.java
+++ b/src/main/java/seedu/address/model/task/PinnedStatus.java
@@ -1,0 +1,111 @@
+package seedu.address.model.task;
+
+/**
+ * Represents the pinned status of a task in SOChedule.
+ * Guarantees: the status is either PINNED or UNPINNED.
+ */
+public class PinnedStatus implements Comparable<PinnedStatus> {
+    public static final String VALIDATION_REGEX = "PINNED|UNPINNED";
+    public static final String MESSAGE_CONSTRAINTS =
+            "Completion Statuses should only either by \"PINNED\" or \"UNPINNED\"";
+
+    private Status pinnedStatus;
+
+    enum Status {
+        PINNED,
+        UNPINNED
+    }
+
+    /**
+     * Constructs an {@code PinnedStatus}.
+     */
+    public PinnedStatus() {
+        pinnedStatus = Status.UNPINNED;
+    }
+
+    /**
+     * Constructs an {@code PinnedStatus}.
+     *
+     * @param cs A valid pinned status ("PINNED" or "UNPINNED").
+     */
+    public PinnedStatus(String cs) {
+        switch (cs) {
+        case "PINNED":
+            pinnedStatus = Status.PINNED;
+            break;
+
+        case "UNPINNED":
+            pinnedStatus = Status.UNPINNED;
+            break;
+
+        default:
+            // should not reach here since validation is pre-done.
+            break;
+        }
+    }
+
+    public boolean isPinned() {
+        return pinnedStatus == Status.PINNED;
+    }
+
+    /**
+     * Flips the pinned status.
+     */
+    public void flipPinnedStatus() {
+        if (pinnedStatus == Status.PINNED) {
+            pinnedStatus = Status.UNPINNED;
+        } else {
+            pinnedStatus = Status.PINNED;
+        }
+    }
+
+    /**
+     * Updates the pinned status of the task to PINNED;
+     * Does nothing if already pinned
+     */
+    public void pin() {
+        pinnedStatus = Status.PINNED;
+    }
+
+    /**
+     * Updates the pinned status of the task to UNPINNED;
+     * Does nothing if already unpinned
+     */
+    public void unpin() {
+        pinnedStatus = Status.UNPINNED;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof PinnedStatus // instanceof handles nulls
+                && pinnedStatus.equals(((PinnedStatus) other).pinnedStatus)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return pinnedStatus.hashCode();
+    }
+
+    /**
+     * Returns a String representation of {@code PinnedStatus}.
+     */
+    public String toString() {
+        if (pinnedStatus == Status.PINNED) {
+            return "Pinned";
+        } else {
+            return "Unpinned";
+        }
+    }
+
+    @Override
+    public int compareTo(PinnedStatus other) {
+        if (isPinned() && !other.isPinned()) {
+            return 1;
+        } else if (!isPinned() && other.isPinned()) {
+            return -1;
+        } else {
+            return 0;
+        }
+    }
+}

--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -22,6 +22,7 @@ public class Task {
     private final Date deadline;
     private final Priority priority;
     private final CompletionStatus completionStatus = new CompletionStatus();
+    private final PinnedStatus pinnedStatus = new PinnedStatus();
     private final Set<Category> categories = new HashSet<>();
     private final Set<Tag> tags = new HashSet<>();
 
@@ -52,6 +53,8 @@ public class Task {
     public CompletionStatus getCompletionStatus() {
         return this.completionStatus;
     }
+
+    public PinnedStatus getPinnedStatus() {return this.pinnedStatus;}
 
     public Set<Category> getCategories() {
         return this.categories;
@@ -127,7 +130,9 @@ public class Task {
                 .append("; Category: ")
                 .append(getCategories())
                 .append("; Completion Status: ")
-                .append(completionStatus.toString());
+                .append(completionStatus.toString())
+                .append("; Pinned Status: ")
+                .append(pinnedStatus.toString());
 
         Set<seedu.address.model.common.Tag> tags = getTags();
         if (!tags.isEmpty()) {

--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -70,6 +70,10 @@ public class Task {
         return completionStatus.isComplete();
     }
 
+    public boolean isPinned() {
+        return pinnedStatus.isPinned();
+    }
+
     public void pin() {
         pinnedStatus.pin();
     }

--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -54,7 +54,9 @@ public class Task {
         return this.completionStatus;
     }
 
-    public PinnedStatus getPinnedStatus() {return this.pinnedStatus;}
+    public PinnedStatus getPinnedStatus() {
+        return this.pinnedStatus;
+    }
 
     public Set<Category> getCategories() {
         return this.categories;
@@ -66,6 +68,14 @@ public class Task {
 
     public boolean isComplete() {
         return completionStatus.isComplete();
+    }
+
+    public void pin() {
+        pinnedStatus.pin();
+    }
+
+    public void unpin() {
+        pinnedStatus.unpin();
     }
 
     public void markTaskAsDone() {

--- a/src/main/java/seedu/address/model/task/TaskComparator.java
+++ b/src/main/java/seedu/address/model/task/TaskComparator.java
@@ -55,6 +55,14 @@ public class TaskComparator implements Comparator<Task> {
      * @param t2 Second {@code Task} to compare.
      */
     public int compare(Task t1, Task t2) {
+        if (t1.isPinned() && !t2.isPinned()) {
+            return 1;
+        }
+
+        if (t2.isPinned() && !t1.isPinned()) {
+            return -1;
+        }
+
         switch (comparingVar) {
         case "name":
             return t1.getName().compareTo(t2.getName());

--- a/src/main/java/seedu/address/model/task/TaskComparator.java
+++ b/src/main/java/seedu/address/model/task/TaskComparator.java
@@ -56,11 +56,11 @@ public class TaskComparator implements Comparator<Task> {
      */
     public int compare(Task t1, Task t2) {
         if (t1.isPinned() && !t2.isPinned()) {
-            return 1;
+            return -1;
         }
 
         if (t2.isPinned() && !t1.isPinned()) {
-            return -1;
+            return 1;
         }
 
         switch (comparingVar) {

--- a/src/main/java/seedu/address/model/task/UniqueTaskList.java
+++ b/src/main/java/seedu/address/model/task/UniqueTaskList.java
@@ -113,6 +113,13 @@ public class UniqueTaskList implements Iterable<Task> {
     }
 
     /**
+     * Sorts the contents of this list given using current {@code comparingVar}.
+     */
+    public void sortDefault() {
+        FXCollections.sort(internalList, taskComparator);
+    }
+
+    /**
      * Returns the number of completed tasks.
      */
     public int getNumCompletedTask() {

--- a/src/main/java/seedu/address/storage/JsonAdaptedTask.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedTask.java
@@ -15,6 +15,7 @@ import seedu.address.model.common.Date;
 import seedu.address.model.common.Name;
 import seedu.address.model.common.Tag;
 import seedu.address.model.task.CompletionStatus;
+import seedu.address.model.task.PinnedStatus;
 import seedu.address.model.task.Priority;
 import seedu.address.model.task.Task;
 
@@ -29,6 +30,7 @@ class JsonAdaptedTask {
     private final String deadline;
     private final String priority;
     private final String completionStatus;
+    private final String pinnedStatus;
     private final List<JsonAdaptedCategory> category = new ArrayList<>();
     private final List<JsonAdaptedTag> tagged = new ArrayList<>();
 
@@ -39,12 +41,14 @@ class JsonAdaptedTask {
     public JsonAdaptedTask(@JsonProperty("name") String name, @JsonProperty("deadline") String deadline,
                              @JsonProperty("priority") String priority,
                              @JsonProperty("completionStatus") String completionStatus,
+                             @JsonProperty("pinnedStatus") String pinnedStatus,
                              @JsonProperty("category") List<JsonAdaptedCategory> category,
                              @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
         this.name = name;
         this.deadline = deadline;
         this.priority = priority;
         this.completionStatus = completionStatus;
+        this.pinnedStatus = pinnedStatus;
         if (category != null) {
             this.category.addAll(category);
         }
@@ -61,6 +65,7 @@ class JsonAdaptedTask {
         deadline = source.getDeadline().toString();
         priority = source.getPriority().toString();
         completionStatus = source.isComplete() ? "COMPLETE" : "INCOMPLETE";
+        pinnedStatus = source.isPinned() ? "PINNED" : "UNPINNED";
         category.addAll(source.getCategories().stream()
                 .map(JsonAdaptedCategory::new)
                 .collect(Collectors.toList()));
@@ -115,6 +120,15 @@ class JsonAdaptedTask {
             throw new IllegalValueException(CompletionStatus.MESSAGE_CONSTRAINTS);
         }
         final CompletionStatus modelCompletionStatus = new CompletionStatus(completionStatus);
+
+        if (pinnedStatus == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    PinnedStatus.class.getSimpleName()));
+        }
+        if (!PinnedStatus.isValidStatus(pinnedStatus)) {
+            throw new IllegalValueException(PinnedStatus.MESSAGE_CONSTRAINTS);
+        }
+        final PinnedStatus modelPinnedStatus = new PinnedStatus(pinnedStatus);
 
         final Set<Tag> modelTags = new HashSet<>(taskTags);
         final Set<Category> modelCategories = new HashSet<>(taskCategories);

--- a/src/main/java/seedu/address/ui/TaskCard.java
+++ b/src/main/java/seedu/address/ui/TaskCard.java
@@ -31,6 +31,8 @@ public class TaskCard extends UiPart<Region> {
     @FXML
     private Label completionStatus;
     @FXML
+    private Label pinnedStatus;
+    @FXML
     private Label category;
     @FXML
     private FlowPane tags;
@@ -46,6 +48,7 @@ public class TaskCard extends UiPart<Region> {
         deadline.setText(task.getDeadline().toString());
         priority.setText(task.getPriority().toString());
         completionStatus.setText(task.getCompletionStatus().toString());
+        pinnedStatus.setText(task.getPinnedStatus().toString());
         category.setText(task.getCategories().toString());
         task.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))

--- a/src/main/resources/view/TaskListCard.fxml
+++ b/src/main/resources/view/TaskListCard.fxml
@@ -30,6 +30,7 @@
             <FlowPane fx:id="tags" />
             <Label fx:id="deadline" styleClass="cell_small_label" text="\$deadline" />
             <Label fx:id="priority" styleClass="cell_small_label" text="\$priority" />
+            <Label fx:id="pinnedStatus" styleClass="cell_small_label" text="\$pinnedStatus" />
             <Label fx:id="completionStatus" styleClass="cell_small_label" text="\$completionStatus" />
             <Label fx:id="category" styleClass="cell_small_label" text="\$category" />
         </VBox>

--- a/src/test/data/JsonSerializableSocheduleTest/duplicateTaskSochedule.json
+++ b/src/test/data/JsonSerializableSocheduleTest/duplicateTaskSochedule.json
@@ -4,6 +4,7 @@
     "deadline" : "2021-01-07",
     "priority" : "8",
     "completionStatus" : "INCOMPLETE",
+    "pinnedStatus" : "UNPINNED",
     "category" : [ "Homework" ],
     "tagged" : [ "MA3110" ]
   }, {
@@ -11,6 +12,7 @@
     "deadline" : "2021-01-07",
     "priority" : "8",
     "completionStatus" : "INCOMPLETE",
+    "pinnedStatus" : "UNPINNED",
     "category" : [ "Homework" ],
     "tagged" : [ "MA3110" ]
   } ],

--- a/src/test/data/JsonSerializableSocheduleTest/invalidTaskSochedule.json
+++ b/src/test/data/JsonSerializableSocheduleTest/invalidTaskSochedule.json
@@ -4,6 +4,7 @@
     "deadline" : "2021-01-07123",
     "priority" : "8",
     "completionStatus" : "INCOMPLETE",
+    "pinnedStatus" : "UNPINNED",
     "category" : [ "Homework" ],
     "tagged" : [ "MA3110" ]
   } ],

--- a/src/test/data/JsonSocheduleStorageTest/invalidAndValidTaskSochedule.json
+++ b/src/test/data/JsonSocheduleStorageTest/invalidAndValidTaskSochedule.json
@@ -4,6 +4,7 @@
     "deadline" : "20211231234-01-07",
     "priority" : "8",
     "completionStatus" : "INCOMPLETE",
+    "pinnedStatus" : "UNPINNED",
     "category" : [ "Homework" ],
     "tagged" : [ "MA3110" ]
   }, {
@@ -11,6 +12,7 @@
     "deadline" : "2021-01-07",
     "priority" : "9",
     "completionStatus" : "COMPLETE",
+    "pinnedStatus" : "UNPINNED",
     "category" : [],
     "tagged" : []
   } ],

--- a/src/test/data/JsonSocheduleStorageTest/invalidTaskSochedule.json
+++ b/src/test/data/JsonSocheduleStorageTest/invalidTaskSochedule.json
@@ -4,6 +4,7 @@
     "deadline" : "20211231234-01-07",
     "priority" : "8",
     "completionStatus" : "INCOMPLETE",
+    "pinnedStatus" : "UNPINNED",
     "category" : [ "Homework" ],
     "tagged" : [ "MA3110" ]
   } ],

--- a/src/test/java/seedu/address/logic/commands/AddEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddEventCommandTest.java
@@ -135,6 +135,14 @@ public class AddEventCommandTest {
             throw new AssertionError("This method should not be called.");
         }
         @Override
+        public void pinTask(Task target) {
+            throw new AssertionError("This method should not be called.");
+        }
+        @Override
+        public void unpinTask(Task target) {
+            throw new AssertionError("This method should not be called.");
+        }
+        @Override
         public void setTask(Task target, Task editedTask) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/AddEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddEventCommandTest.java
@@ -86,6 +86,11 @@ public class AddEventCommandTest {
         }
 
         @Override
+        public void sortTasksDefault() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public int getNumCompletedTask() {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/AddTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddTaskCommandTest.java
@@ -151,6 +151,10 @@ public class AddTaskCommandTest {
         public void sortTasks(String comparingVar) {
             throw new AssertionError("This method should not be called.");
         }
+        @Override
+        public void sortTasksDefault() {
+            throw new AssertionError("This method should not be called.");
+        }
 
         @Override
         public int getNumCompletedTask() {

--- a/src/test/java/seedu/address/logic/commands/AddTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddTaskCommandTest.java
@@ -104,6 +104,14 @@ public class AddTaskCommandTest {
             throw new AssertionError("This method should not be called.");
         }
         @Override
+        public void pinTask(Task target) {
+            throw new AssertionError("This method should not be called.");
+        }
+        @Override
+        public void unpinTask(Task target) {
+            throw new AssertionError("This method should not be called.");
+        }
+        @Override
         public void setTask(Task target, Task editedTask) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/PinTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/PinTaskCommandTest.java
@@ -1,0 +1,150 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.showTaskAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_TASK;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_TASK;
+import static seedu.address.testutil.TypicalTasks.getTypicalSochedule;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.common.Category;
+import seedu.address.model.common.Date;
+import seedu.address.model.common.Name;
+import seedu.address.model.common.Tag;
+import seedu.address.model.task.Priority;
+import seedu.address.model.task.Task;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code PinTaskCommand}.
+ */
+public class PinTaskCommandTest {
+    private Model model = new ModelManager(getTypicalSochedule(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        Task taskToPin = model.getFilteredTaskList().get(INDEX_FIRST_TASK.getZeroBased());
+        PinTaskCommand pinTaskCommand = new PinTaskCommand(INDEX_FIRST_TASK);
+
+        String expectedMessage = PinTaskCommand.MESSAGE_PIN_TASK_SUCCESS;
+        try {
+            CommandResult result = pinTaskCommand.execute(model);
+            assertEquals(result, new CommandResult(expectedMessage));
+        } catch (CommandException ce) {
+            throw new AssertionError("Execution of command should not fail.", ce);
+        }
+
+        ModelManager expectedModel = new ModelManager(model.getSochedule(), new UserPrefs());
+        Task copiedTask = copyTask(taskToPin);
+        expectedModel.setTask(taskToPin, copiedTask);
+        expectedModel.pinTask(copiedTask);
+
+        assertEquals(model.getFilteredTaskList().get(INDEX_FIRST_TASK.getZeroBased()), copiedTask);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredTaskList().size() + 1);
+        PinTaskCommand pinTaskCommand = new PinTaskCommand(outOfBoundIndex);
+
+        assertCommandFailure(pinTaskCommand, model, Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() {
+        showTaskAtIndex(model, INDEX_FIRST_TASK);
+        Task taskToPin = model.getFilteredTaskList().get(INDEX_FIRST_TASK.getZeroBased());
+        PinTaskCommand pinTaskCommand = new PinTaskCommand(INDEX_FIRST_TASK);
+
+        String expectedMessage = PinTaskCommand.MESSAGE_PIN_TASK_SUCCESS;
+        try {
+            CommandResult result = pinTaskCommand.execute(model);
+            assertEquals(result, new CommandResult(expectedMessage));
+        } catch (CommandException ce) {
+            throw new AssertionError("Execution of command should not fail.", ce);
+        }
+
+        ModelManager expectedModel = new ModelManager(model.getSochedule(), new UserPrefs());
+        Task copiedTask = copyTask(taskToPin);
+        expectedModel.setTask(taskToPin, copiedTask);
+        expectedModel.pinTask(copiedTask);
+
+        assertEquals(model.getFilteredTaskList().get(INDEX_FIRST_TASK.getZeroBased()), copiedTask);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showTaskAtIndex(model, INDEX_FIRST_TASK);
+
+        Index outOfBoundIndex = INDEX_SECOND_TASK;
+        // ensures that outOfBoundIndex is still in bounds of sochedule's task list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getSochedule().getTaskList().size());
+
+        PinTaskCommand pinTaskCommand = new PinTaskCommand(outOfBoundIndex);
+
+        assertCommandFailure(pinTaskCommand, model, Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        PinTaskCommand pinFirstTaskCommand = new PinTaskCommand(INDEX_FIRST_TASK);
+        PinTaskCommand pinSecondTaskCommand = new PinTaskCommand(INDEX_SECOND_TASK);
+
+        // same object -> returns true
+        assertTrue(pinFirstTaskCommand.equals(pinFirstTaskCommand));
+
+        // same values -> returns true
+        PinTaskCommand deleteFirstCommandCopy = new PinTaskCommand(INDEX_FIRST_TASK);
+        assertTrue(pinFirstTaskCommand.equals(deleteFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(pinFirstTaskCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(pinFirstTaskCommand.equals(null));
+
+        // different task -> returns false
+        assertFalse(pinFirstTaskCommand.equals(pinSecondTaskCommand));
+    }
+
+    /**
+     * Copies the task given and returns a new task with the same details as the given task.
+     *
+     * @param taskToCopy task to be copied, here is the task to pin.
+     * @return a copied task.
+     */
+    private static Task copyTask(Task taskToCopy) {
+        Name taskName = taskToCopy.getName();
+        Date deadline = taskToCopy.getDeadline();
+        Priority priority = taskToCopy.getPriority();
+        Set<Category> categories = taskToCopy.getCategories();
+        Set<Tag> tags = taskToCopy.getTags();
+
+        Task copiedTask = new Task(taskName, deadline, priority, categories, tags);
+        if (taskToCopy.isComplete()) {
+            copiedTask.markTaskAsDone();
+        }
+        return copiedTask;
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show no task.
+     */
+    private void showNoTask(Model model) {
+        model.updateFilteredTaskList(p -> false);
+
+        assertTrue(model.getFilteredTaskList().isEmpty());
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/PinTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/PinTaskCommandTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
-import static seedu.address.logic.commands.CommandTestUtil.showTaskAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_TASK;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_TASK;
 import static seedu.address.testutil.TypicalTasks.getTypicalSochedule;
@@ -34,8 +33,10 @@ public class PinTaskCommandTest {
     private Model model = new ModelManager(getTypicalSochedule(), new UserPrefs());
 
     @Test
-    public void execute_validIndexUnfilteredList_success() {
+    public void execute_validIndexList_success() {
         Task taskToPin = model.getFilteredTaskList().get(INDEX_FIRST_TASK.getZeroBased());
+        Task taskToPinCopy = copyTask(taskToPin); //copy to preserve integrity
+        model.setTask(taskToPin, taskToPinCopy);
         PinTaskCommand pinTaskCommand = new PinTaskCommand(INDEX_FIRST_TASK);
 
         String expectedMessage = PinTaskCommand.MESSAGE_PIN_TASK_SUCCESS;
@@ -51,47 +52,12 @@ public class PinTaskCommandTest {
         expectedModel.setTask(taskToPin, copiedTask);
         expectedModel.pinTask(copiedTask);
 
-        assertEquals(model.getFilteredTaskList().get(INDEX_FIRST_TASK.getZeroBased()), copiedTask);
+        assertEquals(model.getFilteredTaskList(), expectedModel.getFilteredTaskList());
     }
 
     @Test
-    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+    public void execute_invalidIndexList_throwsCommandException() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredTaskList().size() + 1);
-        PinTaskCommand pinTaskCommand = new PinTaskCommand(outOfBoundIndex);
-
-        assertCommandFailure(pinTaskCommand, model, Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
-    }
-
-    @Test
-    public void execute_validIndexFilteredList_success() {
-        showTaskAtIndex(model, INDEX_FIRST_TASK);
-        Task taskToPin = model.getFilteredTaskList().get(INDEX_FIRST_TASK.getZeroBased());
-        PinTaskCommand pinTaskCommand = new PinTaskCommand(INDEX_FIRST_TASK);
-
-        String expectedMessage = PinTaskCommand.MESSAGE_PIN_TASK_SUCCESS;
-        try {
-            CommandResult result = pinTaskCommand.execute(model);
-            assertEquals(result, new CommandResult(expectedMessage));
-        } catch (CommandException ce) {
-            throw new AssertionError("Execution of command should not fail.", ce);
-        }
-
-        ModelManager expectedModel = new ModelManager(model.getSochedule(), new UserPrefs());
-        Task copiedTask = copyTask(taskToPin);
-        expectedModel.setTask(taskToPin, copiedTask);
-        expectedModel.pinTask(copiedTask);
-
-        assertEquals(model.getFilteredTaskList().get(INDEX_FIRST_TASK.getZeroBased()), copiedTask);
-    }
-
-    @Test
-    public void execute_invalidIndexFilteredList_throwsCommandException() {
-        showTaskAtIndex(model, INDEX_FIRST_TASK);
-
-        Index outOfBoundIndex = INDEX_SECOND_TASK;
-        // ensures that outOfBoundIndex is still in bounds of sochedule's task list
-        assertTrue(outOfBoundIndex.getZeroBased() < model.getSochedule().getTaskList().size());
-
         PinTaskCommand pinTaskCommand = new PinTaskCommand(outOfBoundIndex);
 
         assertCommandFailure(pinTaskCommand, model, Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
@@ -137,14 +103,5 @@ public class PinTaskCommandTest {
             copiedTask.markTaskAsDone();
         }
         return copiedTask;
-    }
-
-    /**
-     * Updates {@code model}'s filtered list to show no task.
-     */
-    private void showNoTask(Model model) {
-        model.updateFilteredTaskList(p -> false);
-
-        assertTrue(model.getFilteredTaskList().isEmpty());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/UnpinTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnpinTaskCommandTest.java
@@ -1,0 +1,113 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_TASK;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_TASK;
+import static seedu.address.testutil.TypicalTasks.getTypicalSochedule;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.common.Category;
+import seedu.address.model.common.Date;
+import seedu.address.model.common.Name;
+import seedu.address.model.common.Tag;
+import seedu.address.model.task.Priority;
+import seedu.address.model.task.Task;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code UnpinTaskCommand}.
+ */
+public class UnpinTaskCommandTest {
+    private Model model = new ModelManager(getTypicalSochedule(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexList_success() {
+        Task taskToUnpin = model.getFilteredTaskList().get(INDEX_FIRST_TASK.getZeroBased());
+        Task taskToUnpinCopy = copyTask(taskToUnpin); //make a copy to preserve integrity
+        model.setTask(taskToUnpin, taskToUnpinCopy);
+        taskToUnpinCopy.pin(); //have to initialize to pinned
+        UnpinTaskCommand unpinTaskCommand = new UnpinTaskCommand(INDEX_FIRST_TASK);
+
+        String expectedMessage = UnpinTaskCommand.MESSAGE_PIN_TASK_SUCCESS;
+        try {
+            CommandResult result = unpinTaskCommand.execute(model);
+            assertEquals(result, new CommandResult(expectedMessage));
+        } catch (CommandException ce) {
+            throw new AssertionError("Execution of command should not fail.", ce);
+        }
+
+        ModelManager expectedModel = new ModelManager(model.getSochedule(), new UserPrefs());
+        Task copiedTask = copyTask(taskToUnpin);
+        expectedModel.setTask(taskToUnpin, copiedTask);
+        copiedTask.pin();
+        expectedModel.unpinTask(copiedTask);
+
+        assertEquals(model.getFilteredTaskList(), expectedModel.getFilteredTaskList());
+    }
+
+    @Test
+    public void execute_invalidIndexList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredTaskList().size() + 1);
+        UnpinTaskCommand unpinTaskCommand = new UnpinTaskCommand(outOfBoundIndex);
+
+        assertCommandFailure(unpinTaskCommand, model, Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        UnpinTaskCommand unpinFirstTaskCommand = new UnpinTaskCommand(INDEX_FIRST_TASK);
+        UnpinTaskCommand unpinSecondTaskCommand = new UnpinTaskCommand(INDEX_SECOND_TASK);
+
+        // same object -> returns true
+        assertTrue(unpinFirstTaskCommand.equals(unpinFirstTaskCommand));
+
+        // same values -> returns true
+        UnpinTaskCommand unpinFirstTaskCommandCopy = new UnpinTaskCommand(INDEX_FIRST_TASK);
+        assertTrue(unpinFirstTaskCommand.equals(unpinFirstTaskCommandCopy));
+
+        // different types -> returns false
+        assertFalse(unpinFirstTaskCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(unpinFirstTaskCommand.equals(null));
+
+        // different task -> returns false
+        assertFalse(unpinFirstTaskCommand.equals(unpinSecondTaskCommand));
+
+    }
+
+    /**
+     * Copies the task given and returns a new task with the same details as the given task.
+     *
+     * @param taskToCopy task to be copied, here is the task to pin.
+     * @return a copied task.
+     */
+    private static Task copyTask(Task taskToCopy) {
+        Name taskName = taskToCopy.getName();
+        Date deadline = taskToCopy.getDeadline();
+        Priority priority = taskToCopy.getPriority();
+        Set<Category> categories = taskToCopy.getCategories();
+        Set<Tag> tags = taskToCopy.getTags();
+
+        Task copiedTask = new Task(taskName, deadline, priority, categories, tags);
+        if (taskToCopy.isComplete()) {
+            copiedTask.markTaskAsDone();
+        }
+        if (taskToCopy.isPinned()) {
+            copiedTask.pin();
+        }
+        return copiedTask;
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/UnpinTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnpinTaskCommandTest.java
@@ -40,7 +40,7 @@ public class UnpinTaskCommandTest {
         taskToUnpinCopy.pin(); //have to initialize to pinned
         UnpinTaskCommand unpinTaskCommand = new UnpinTaskCommand(INDEX_FIRST_TASK);
 
-        String expectedMessage = UnpinTaskCommand.MESSAGE_PIN_TASK_SUCCESS;
+        String expectedMessage = UnpinTaskCommand.MESSAGE_UNPIN_TASK_SUCCESS;
         try {
             CommandResult result = unpinTaskCommand.execute(model);
             assertEquals(result, new CommandResult(expectedMessage));

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -25,6 +25,7 @@ import seedu.address.model.task.Task;
 import seedu.address.model.task.TaskComparator;
 import seedu.address.model.task.TaskNameContainsKeywordsPredicate;
 import seedu.address.testutil.SocheduleBuilder;
+import seedu.address.testutil.TaskBuilder;
 import seedu.address.testutil.TypicalEvents;
 import seedu.address.testutil.TypicalTasks;
 
@@ -126,6 +127,40 @@ public class ModelManagerTest {
     @Test
     public void getFilteredEventList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredEventList().remove(0));
+    }
+
+    @Test
+    public void pinTask_returnsTrue() {
+        Task t = new TaskBuilder(ASSIGNMENT).build();
+        modelManager.addTask(t);
+        modelManager.pinTask(t);
+        assertTrue(t.isPinned());
+    }
+
+    @Test
+    public void unpinTask_returnsTrue() {
+        Task t = new TaskBuilder(ASSIGNMENT).build();
+        modelManager.addTask(t);
+        modelManager.pinTask(t);
+        assertTrue(t.isPinned());
+
+        modelManager.unpinTask(t);
+        assertFalse(t.isPinned());
+    }
+
+    @Test
+    public void pinTask_alreadyPinned_nothingHappen() {
+        Task t = new TaskBuilder(ASSIGNMENT).build();
+        modelManager.addTask(t);
+        modelManager.pinTask(t);
+        assertDoesNotThrow(() -> modelManager.pinTask(t));
+    }
+
+    @Test
+    public void unpinTask_alreadyUnpinned_nothingHappen() {
+        Task t = new TaskBuilder(ASSIGNMENT).build();
+        modelManager.addTask(t);
+        assertDoesNotThrow(() -> modelManager.unpinTask(t));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/SocheduleTest.java
+++ b/src/test/java/seedu/address/model/SocheduleTest.java
@@ -164,6 +164,40 @@ public class SocheduleTest {
     }
 
     @Test
+    public void pinTask_returnsTrue() {
+        Task t = new TaskBuilder(ASSIGNMENT).build();
+        sochedule.addTask(t);
+        sochedule.pinTask(t);
+        assertTrue(t.isPinned());
+    }
+
+    @Test
+    public void unpinTask_returnsTrue() {
+        Task t = new TaskBuilder(ASSIGNMENT).build();
+        sochedule.addTask(t);
+        sochedule.pinTask(t);
+        assertTrue(t.isPinned());
+
+        sochedule.unpinTask(t);
+        assertFalse(t.isPinned());
+    }
+
+    @Test
+    public void pinTask_alreadyPinned_nothingHappen() {
+        Task t = new TaskBuilder(ASSIGNMENT).build();
+        sochedule.addTask(t);
+        sochedule.pinTask(t);
+        assertDoesNotThrow(() -> sochedule.pinTask(t));
+    }
+
+    @Test
+    public void unpinTask_alreadyUnpinned_nothingHappen() {
+        Task t = new TaskBuilder(ASSIGNMENT).build();
+        sochedule.addTask(t);
+        assertDoesNotThrow(() -> sochedule.unpinTask(t));
+    }
+
+    @Test
     public void sortTasks_nullList_nothingThrown() {
         assertDoesNotThrow(() ->
                 sochedule.sortTasks(TaskComparator.getAcceptedVar().get(0)));

--- a/src/test/java/seedu/address/model/task/PinnedStatusTest.java
+++ b/src/test/java/seedu/address/model/task/PinnedStatusTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.TypicalTasks.ASSIGNMENT;
 import static seedu.address.testutil.TypicalTasks.EXERCISE;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.testutil.TaskBuilder;
@@ -25,14 +24,16 @@ public class PinnedStatusTest {
     }
 
     @Test
-    @Disabled
-    //disabled until model support for pinned status
     public void compareTest() {
-        assertEquals(ASSIGNMENT.getCompletionStatus().compareTo(EXERCISE.getCompletionStatus()), 0);
+        assertEquals(ASSIGNMENT.getPinnedStatus().compareTo(EXERCISE.getPinnedStatus()), 0);
 
         Task assignment = new TaskBuilder(ASSIGNMENT).build();
-        assignment.markTaskAsDone();
-        assertEquals(assignment.getCompletionStatus().compareTo(EXERCISE.getCompletionStatus()), 1);
-        assertEquals(EXERCISE.getCompletionStatus().compareTo(assignment.getCompletionStatus()), -1);
+
+        assignment.pin();
+        assertEquals(assignment.getPinnedStatus().compareTo(EXERCISE.getPinnedStatus()), 1);
+        assertEquals(EXERCISE.getPinnedStatus().compareTo(assignment.getPinnedStatus()), -1);
+
+        assignment.unpin();
+        assertEquals(ASSIGNMENT.getPinnedStatus().compareTo(EXERCISE.getPinnedStatus()), 0);
     }
 }

--- a/src/test/java/seedu/address/model/task/PinnedStatusTest.java
+++ b/src/test/java/seedu/address/model/task/PinnedStatusTest.java
@@ -1,0 +1,38 @@
+package seedu.address.model.task;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.TypicalTasks.ASSIGNMENT;
+import static seedu.address.testutil.TypicalTasks.EXERCISE;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.TaskBuilder;
+
+public class PinnedStatusTest {
+
+    @Test
+    public void isValidPinnedStatus() {
+
+        // invalid pinnedStatus
+        assertFalse(PinnedStatus.isValidStatus("")); // empty string
+
+        // valid pinnedStatus
+        assertTrue(PinnedStatus.isValidStatus("PINNED"));
+        assertTrue(PinnedStatus.isValidStatus("UNPINNED"));
+    }
+
+    @Test
+    @Disabled
+    //disabled until model support for pinned status
+    public void compareTest() {
+        assertEquals(ASSIGNMENT.getCompletionStatus().compareTo(EXERCISE.getCompletionStatus()), 0);
+
+        Task assignment = new TaskBuilder(ASSIGNMENT).build();
+        assignment.markTaskAsDone();
+        assertEquals(assignment.getCompletionStatus().compareTo(EXERCISE.getCompletionStatus()), 1);
+        assertEquals(EXERCISE.getCompletionStatus().compareTo(assignment.getCompletionStatus()), -1);
+    }
+}

--- a/src/test/java/seedu/address/model/task/TaskComparatorTest.java
+++ b/src/test/java/seedu/address/model/task/TaskComparatorTest.java
@@ -14,6 +14,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.model.task.exceptions.InvalidTaskComparatorVariableException;
+import seedu.address.testutil.TaskBuilder;
 
 public class TaskComparatorTest {
     private static final String INVALID_INPUT = "*%&!#*)";
@@ -87,5 +88,26 @@ public class TaskComparatorTest {
                 taskComparator.compare(ASSIGNMENT, EXERCISE));
         assertEquals(EXERCISE.getDeadline().compareTo(LAB.getDeadline()),
                 taskComparator.compare(EXERCISE, LAB));
+    }
+
+    //none pinned tested in above test cases
+
+    @Test
+    public void compare_twoValidInput_withOnePinned() {
+        Task assignment = new TaskBuilder(ASSIGNMENT).build();
+        assignment.pin();
+        assertEquals(assignment.getPinnedStatus().compareTo(EXERCISE.getPinnedStatus()),
+                taskComparator.compare(assignment, EXERCISE));
+    }
+
+    @Test
+    public void compare_twoValidInput_withTwoPinned() {
+        Task assignment = new TaskBuilder(ASSIGNMENT).build();
+        assignment.pin();
+        Task exercise = new TaskBuilder(EXERCISE).build();
+        exercise.pin();
+        //since both are pinned, should default to comparingVar (=name)
+        assertEquals(assignment.getName().compareTo(exercise.getName()),
+                taskComparator.compare(assignment, exercise));
     }
 }

--- a/src/test/java/seedu/address/model/task/TaskComparatorTest.java
+++ b/src/test/java/seedu/address/model/task/TaskComparatorTest.java
@@ -96,8 +96,9 @@ public class TaskComparatorTest {
     public void compare_twoValidInput_withOnePinned() {
         Task assignment = new TaskBuilder(ASSIGNMENT).build();
         assignment.pin();
+        //take reverse ordering of compare as pinned tasks come before unpinned tasks in list
         assertEquals(assignment.getPinnedStatus().compareTo(EXERCISE.getPinnedStatus()),
-                taskComparator.compare(assignment, EXERCISE));
+                taskComparator.compare(EXERCISE, assignment));
     }
 
     @Test

--- a/src/test/java/seedu/address/storage/JsonAdaptedTaskTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedTaskTest.java
@@ -15,6 +15,7 @@ import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.common.Date;
 import seedu.address.model.common.Name;
 import seedu.address.model.task.CompletionStatus;
+import seedu.address.model.task.PinnedStatus;
 import seedu.address.model.task.Priority;
 
 public class JsonAdaptedTaskTest {
@@ -22,6 +23,7 @@ public class JsonAdaptedTaskTest {
     private static final String INVALID_DEADLINE = ",!@#%$";
     private static final String INVALID_PRIORITY = ",!@#%$";
     private static final String INVALID_COMPLETION = ",!@#%$";
+    private static final String INVALID_PINNED = ",!@#%$";
     private static final String INVALID_TAGS = ",!@#%$";
     private static final String INVALID_CATEGORIES = ",!@#%$";
 
@@ -29,6 +31,7 @@ public class JsonAdaptedTaskTest {
     private static final String VALID_DEADLINE = ASSIGNMENT.getDeadline().toString();
     private static final String VALID_PRIORITY = ASSIGNMENT.getPriority().toString();
     private static final String VALID_COMPLETION = ASSIGNMENT.getCompletionStatus().toString();
+    private static final String VALID_PINNED = ASSIGNMENT.getPinnedStatus().toString();
     private static final List<JsonAdaptedTag> VALID_TAGS = ASSIGNMENT.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
@@ -46,7 +49,7 @@ public class JsonAdaptedTaskTest {
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedTask person =
                 new JsonAdaptedTask(INVALID_NAME, VALID_DEADLINE, VALID_PRIORITY,
-                        VALID_COMPLETION, VALID_CATEGORIES, VALID_TAGS);
+                        VALID_COMPLETION, VALID_PINNED, VALID_CATEGORIES, VALID_TAGS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -55,7 +58,7 @@ public class JsonAdaptedTaskTest {
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedTask person =
                 new JsonAdaptedTask(null, VALID_DEADLINE, VALID_PRIORITY,
-                        VALID_COMPLETION, VALID_CATEGORIES, VALID_TAGS);
+                        VALID_COMPLETION, VALID_PINNED, VALID_CATEGORIES, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -64,7 +67,7 @@ public class JsonAdaptedTaskTest {
     public void toModelType_invalidDeadline_throwsIllegalValueException() {
         JsonAdaptedTask person =
                 new JsonAdaptedTask(VALID_NAME, INVALID_DEADLINE, VALID_PRIORITY,
-                        VALID_COMPLETION, VALID_CATEGORIES, VALID_TAGS);
+                        VALID_COMPLETION, VALID_PINNED, VALID_CATEGORIES, VALID_TAGS);
         String expectedMessage = Date.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -73,7 +76,7 @@ public class JsonAdaptedTaskTest {
     public void toModelType_nullDeadline_throwsIllegalValueException() {
         JsonAdaptedTask person =
                 new JsonAdaptedTask(VALID_NAME, null, VALID_PRIORITY,
-                        VALID_COMPLETION, VALID_CATEGORIES, VALID_TAGS);
+                        VALID_COMPLETION, VALID_PINNED, VALID_CATEGORIES, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Date.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -82,7 +85,7 @@ public class JsonAdaptedTaskTest {
     public void toModelType_invalidPriority_throwsIllegalValueException() {
         JsonAdaptedTask person =
                 new JsonAdaptedTask(VALID_NAME, VALID_DEADLINE, INVALID_PRIORITY,
-                        VALID_COMPLETION, VALID_CATEGORIES, VALID_TAGS);
+                        VALID_COMPLETION, VALID_PINNED, VALID_CATEGORIES, VALID_TAGS);
         String expectedMessage = Priority.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -91,7 +94,7 @@ public class JsonAdaptedTaskTest {
     public void toModelType_invalidCompletion_throwsIllegalValueException() {
         JsonAdaptedTask person =
                 new JsonAdaptedTask(VALID_NAME, VALID_DEADLINE, VALID_PRIORITY,
-                        INVALID_COMPLETION, VALID_CATEGORIES, VALID_TAGS);
+                        INVALID_COMPLETION, VALID_PINNED, VALID_CATEGORIES, VALID_TAGS);
         String expectedMessage = CompletionStatus.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -100,8 +103,26 @@ public class JsonAdaptedTaskTest {
     public void toModelType_nullCompletion_throwsIllegalValueException() {
         JsonAdaptedTask person =
                 new JsonAdaptedTask(VALID_NAME, VALID_DEADLINE, VALID_PRIORITY,
-                        null, VALID_CATEGORIES, VALID_TAGS);
+                        null, VALID_PINNED, VALID_CATEGORIES, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, CompletionStatus.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidPinned_throwsIllegalValueException() {
+        JsonAdaptedTask person =
+                new JsonAdaptedTask(VALID_NAME, VALID_DEADLINE, VALID_PRIORITY,
+                        VALID_COMPLETION, INVALID_PINNED, VALID_CATEGORIES, VALID_TAGS);
+        String expectedMessage = PinnedStatus.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullPinned_throwsIllegalValueException() {
+        JsonAdaptedTask person =
+                new JsonAdaptedTask(VALID_NAME, VALID_DEADLINE, VALID_PRIORITY,
+                        VALID_COMPLETION, null, VALID_CATEGORIES, VALID_TAGS);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, PinnedStatus.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
@@ -111,7 +132,7 @@ public class JsonAdaptedTaskTest {
         invalidTags.add(new JsonAdaptedTag(INVALID_TAGS));
         JsonAdaptedTask task =
                 new JsonAdaptedTask(VALID_NAME, VALID_DEADLINE, VALID_PRIORITY,
-                        VALID_COMPLETION, VALID_CATEGORIES, invalidTags);
+                        VALID_COMPLETION, VALID_PINNED, VALID_CATEGORIES, invalidTags);
         assertThrows(IllegalValueException.class, task::toModelType);
     }
 
@@ -121,7 +142,7 @@ public class JsonAdaptedTaskTest {
         invalidCategories.add(new JsonAdaptedCategory(INVALID_CATEGORIES));
         JsonAdaptedTask task =
                 new JsonAdaptedTask(VALID_NAME, VALID_DEADLINE, VALID_PRIORITY,
-                        VALID_COMPLETION, invalidCategories, VALID_TAGS);
+                        VALID_COMPLETION, VALID_PINNED, invalidCategories, VALID_TAGS);
         assertThrows(IllegalValueException.class, task::toModelType);
     }
 }


### PR DESCRIPTION
Added full support to pin_task and unpin_task
- Command and parser support.
- UG and DG updated.
- Unit Tests written.

Added additional attributes to existing classes
- Task now have an additional attribute, pinnedStatus, to track whether the Task is pinned.
- Storage now reads and writes a Task's pinnedStatus into sochedule.json to ensure persistency.
- UI now shows whether a Task is pinned, or not.
- Test dependency issues fully resolved.

Overloaded previously implemented functions
- TaskComparator#compare(Task, Task) now takes task pinnedStatus into consideration.

closes #151 